### PR TITLE
feature: adds working-directory argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,12 @@
+name: "Expo Semantic Release"
+description: "An Expo implementation for semantic release, so you don't have to bother."
+inputs:
+  working-directory: # id of input
+    description: "Path to run docker entry"
+    required: false
+    default: '.'
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  args:
+    - ${{ inputs.working-directory }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -l
 
-sh -c "npm run semantic-release"
+sh -c "cd ${1} && npm run semantic-release"


### PR DESCRIPTION
Can now define working directory in Github Actions if package.json is not in root directory.

Example:

*main.workflow*:
```yaml
name: Workflow
on:
  push:
    branches:
      - master
jobs:
  expoSemanticRelease:
    name: Semantic release
    runs-on: ubuntu-latest
    steps:
      ...
      - name: Semantic release Expo
        uses: mgibeau/semantic-release-expo-github-action@master
        with:
          working-directory: ./subdirectory
        env:
          GITHUB_TOKEN: ${{ GITHUB_TOKEN }}
```